### PR TITLE
Refactor GPS Distance Calculation

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -133,8 +133,11 @@ def process(data, port, sequence_id, gateways):
         output['max_rssi'] = max(output['max_rssi'], gateway.get('rssi', MIN_RSSI))
 
         if output['has_gps']:
-            if 'location' in gateway:
-                distance = int(circleDistance(output, gateway['location'])) 
+            loc = gateway.get('location', {})
+            lat = loc.get('latitude')
+            lon = loc.get('longitude')
+            if lat is not None and lon is not None:
+                distance = int(circleDistance(output, loc)) 
                 output['min_distance'] = min(output['min_distance'], distance)
                 output['max_distance'] = max(output['max_distance'], distance)
 


### PR DESCRIPTION
This pull request includes a change to the `process` function in the `python/server.py` file to improve the handling of gateway location data. The change ensures that both latitude and longitude are present before calculating the distance, which prevents potential errors when location data is incomplete. 

### Reasoning
Chirpstack can include the location key in the gateway metadata with 0 keys bypassing the current if statement of `if location in gateway`

### Updates
* [`python/server.py`](diffhunk://#diff-7027c1077421eeea1b31e36c5404094ee35377e5777b11282c719f47e000ba32L136-R140): Updated the `process` function to check for both `latitude` and `longitude` in the gateway location data before calculating the distance.